### PR TITLE
docs: expand backend basics tutorials

### DIFF
--- a/docs/tutorials/backend/05_nodes_and_events.md
+++ b/docs/tutorials/backend/05_nodes_and_events.md
@@ -1,53 +1,131 @@
 # 05 节点实现与事件联动
 
+夜巡队伍终于进入“设备车间”。从 LLM 到 HTTP，再到循环控制，每台机器都栖身于 `api/core/workflow/nodes/` 目录的各个仓库。墙上挂着的，是
+`node_events` 与 `graph_events` 两套广播喇叭，负责告诉调度中心每一次开机、暂停与失败。跟着向导的手电筒，我们来拆解节点的骨架、常见机种
+的运行方式，以及事件如何一路冒泡到图引擎层。
+
 ## 学习成果
-- 熟悉节点基类的 `_run()` 模式、输入解析、输出写入流程
-- 对比 LLM、HTTP、Loop 等典型节点的实现细节
-- 解释 `node_events` 与 `graph_events` 在节点生命周期中的作用
+
+- 熟悉节点基类的 `_run()`、事件分发与变量读写流程。
+- 对比 LLM、HTTP、Loop 等典型节点，掌握输入解析、错误策略与输出回写的差异。
+- 理清 `node_events` 与 `graph_events` 的职责分工，理解事件从节点到图引擎再到服务层的传播链路。
 
 ## 引导问题
-1. `BaseNode` 提供了哪些通用能力？子类需要覆盖哪些方法？
-2. 节点如何解析输入变量、读取变量池并输出结果？
-3. 事件是如何从节点执行传播到引擎、再到上层服务或监听器的？
+
+1. `Node.run()` 在进入子类 `_run()` 前后做了哪些公共工作？
+2. 节点如何借助变量池、模板解析器拿到上游输出，并把结果再写回去？
+3. `NodeRunResult`、`StreamChunkEvent`、`NodeRunSucceededEvent` 等事件之间是什么关系？
 
 ## 必读源码
+
 - `api/core/workflow/nodes/base/node.py:1`
 - `api/core/workflow/nodes/node_mapping.py:1`
-- 典型节点：
-  - `api/core/workflow/nodes/llm/llm_node.py:1`
-  - `api/core/workflow/nodes/http_request/http_request_node.py:1`
+- 典型节点实现：
+  - `api/core/workflow/nodes/llm/node.py:1`
+  - `api/core/workflow/nodes/http_request/node.py:1`
   - `api/core/workflow/nodes/loop/loop_node.py:1`
-- `api/core/workflow/nodes/_utils`（若存在的工具函数）
 - `api/core/workflow/node_events/__init__.py:1`
 - `api/core/workflow/graph_events/__init__.py:1`
 
 ## Walkthrough
-1. **节点基类**  
-   - 阅读 `BaseNode` 的初始化、`run()`、`_run()`、输入输出处理流程。  
-   - 注意异常处理、metadata、变量映射等逻辑。
-2. **节点注册与版本管理**  
-   - 查看 `node_mapping.py` 如何维护 `NODE_TYPE_CLASSES_MAPPING` 与版本策略。  
-   - 理解引擎如何根据节点类型实例化具体类。
-3. **典型节点对比**  
-   - LLM 节点：关注 prompt 构造、模型选择、输出结构。  
-   - HTTP 节点：观察请求构造、错误处理、重试机制。  
-   - Loop/Iteration 节点：记录控制流处理、迭代变量管理。
-4. **事件传播链**  
-   - 研究节点执行期间触发的 `NodeRunStartedEvent`、`NodeRunSucceededEvent` 等。  
-   - 追踪 `GraphNodeEventBase` 如何在引擎和服务层间流动。
-5. **调试与扩展**  
-   - 指出添加新节点时需要实现的接口、需要补充的事件与测试。
+
+### 1. 基座：Node 把节点抽象成同一个“壳”
+
+所有节点都继承自 `Node` 基类。构造函数会记录租户、应用、调用方信息，并将运行状态嵌入 `GraphRuntimeState` 中，方便随时访问变量池。`run()` 方
+法统一生成 `NodeRunStartedEvent`，随后调用子类 `_run()`，并负责把 `NodeRunResult` 或 `node_events` 转换为图层级事件：
+
+```python
+# api/core/workflow/nodes/base/node.py
+def run(self) -> Generator[GraphNodeEventBase, None, None]:
+    if not self._node_execution_id:
+        self._node_execution_id = str(uuid4())
+    start_event = NodeRunStartedEvent(...)
+    yield start_event
+    try:
+        result = self._run()
+        if isinstance(result, NodeRunResult):
+            yield self._convert_node_run_result_to_graph_node_event(result)
+            return
+        for event in result:
+            if isinstance(event, NodeEventBase):
+                yield self._dispatch(event)
+            else:
+                yield event
+    except Exception as e:
+        yield NodeRunFailedEvent(..., error=str(e))
+```
+
+`_dispatch` 基于 `functools.singledispatchmethod`，把 `StreamChunkEvent`、`PauseRequestedEvent` 等节点级事件翻译成 Graph 层广播，实现“节点只关心
+局部细节，引擎负责统一语言”的分层原则。【F:api/core/workflow/nodes/base/node.py†L1-L199】【F:api/core/workflow/nodes/base/node.py†L200-L345】
+
+### 2. 输入输出：变量池、模板与默认值
+
+子类通常通过 `BaseNodeData`（`get_base_node_data()` 返回）描述节点配置，包含变量选择器、默认值、错误策略等信息。基类提供 `extract_variable_sel
+ector_to_variable_mapping()` 帮助解析 DSL 中的 `#node.result#` 引用，Loop/Iteration 则会覆写 `_extract_variable_selector_to_variable_mapping()`
+，将嵌套图的变量依赖映射出来。变量读取时常配合 `VariableTemplateParser` 与 `VariablePool`，先把选择器转成 `Segment`，再拿值或写回系统变量。【F:api/core/workflow/nodes/base/node.py†L200-L345】【F:api/core/workflow/nodes/loop/loop_node.py†L1-L200】
+
+默认的错误策略、重试配置、标题等信息都通过 `_get_error_strategy()`、`_get_retry_config()` 等抽象方法交由子类实现，再由基类的 `error_strategy`
+属性统一暴露，确保 UI、日志与持久化层获得一致的元数据。【F:api/core/workflow/nodes/base/node.py†L200-L345】
+
+### 3. 注册处：node_mapping 维系类型与版本
+
+`DifyNodeFactory`（`api/core/workflow/nodes/node_factory.py`）会根据节点类型从 `NODE_TYPE_CLASSES_MAPPING` 中挑选 `latest` 版本的类并实例化。某些节点（
+例如 Tool、Agent）同时保留旧版本条目，允许历史工作流在不迁移数据的情况下继续运行。想扩展新节点，只需在映射表里登记对应类型与版本，再让工厂
+能找到它。【F:api/core/workflow/nodes/node_factory.py†L1-L120】
+
+### 4. 典型节点：从数据准备到事件产出
+
+**LLM 节点**（`llm/node.py`）的 `_run()` 是最长的流水线：
+
+- 先把聊天模板转换成内部结构，再调用 `_fetch_inputs` / `_fetch_jinja_inputs` 汇总变量。
+- 如果启用了视觉功能，会通过 `llm_utils.fetch_files()` 从变量池中拿文件并拼入 prompt。
+- 调用模型时兼容流式与同步返回，借助 `StreamChunkEvent`、`StreamCompletedEvent` 逐块推送文本或 Structured Output，最后将 `LLMUsage`
+累积回 `GraphRuntimeState`。【F:api/core/workflow/nodes/llm/node.py†L1-L200】【F:api/core/workflow/nodes/llm/node.py†L200-L400】
+
+**HTTP 节点**（`http_request/node.py`）的 `_run()` 更像一次受控的 API 调用：
+
+- `Executor` 负责组装请求与日志，支持 `timeout`、SSL 校验和重试参数。
+- 收到响应后，会根据状态码生成 `NodeRunResult`，同时把响应体、头信息、附件等写入 `outputs`，供下游节点直接引用。
+- 当命中错误策略或重试条件时，节点返回 `FAILED` 状态并附带错误类型，调度层可以据此选择兜底或终止。【F:api/core/workflow/nodes/http_request/node.py†L1-L160】
+
+**Loop 节点**（`loop/loop_node.py`）则是流程控制器：
+
+- 初始化循环变量后，逐次创建子图 `GraphEngine` 执行，并把每轮输出累积在原始变量池。
+- 通过 `LoopStartedEvent`、`LoopNextEvent`、`LoopSucceededEvent` 等事件广播进度，同时统计每轮耗时与 Token 使用量。
+- 如果触发 Break 条件或内部节点异常，会抛出 `LoopFailedEvent` 或 `GraphRunFailedEvent`，供上层及时中断。【F:api/core/workflow/nodes/loop/loop_node.py†L1-L200】
+
+### 5. 事件广播：node_events 与 graph_events 的握手
+
+`node_events` 定义的是“节点内部视角”的事件（例如 `StreamChunkEvent`、`LoopNextEvent`），子类 `_run()` 可以直接 `yield`。基类通过 `_dispatch`
+转换为 `graph_events`（如 `NodeRunStreamChunkEvent`、`NodeRunSucceededEvent`），这些事件再被 Graph Engine 层消费：
+
+- `GraphEngine` 监听所有 `GraphNodeEventBase`，同步状态或交给 Layer（如 DebugLoggingLayer、PersistenceLayer）处理。
+- `WorkflowPersistenceLayer` 将节点运行结果序列化存库；`DebugLoggingLayer` 则打印丰富日志，帮助调试。【F:api/core/workflow/node_events/__init__.py†L1-L40】【F:api/core/workflow/graph_events/__init__.py†L1-L60】
+
+因此，我们可以把事件流理解成三级广播：节点 `_run()` → `node_events` → 基类 `_dispatch` → `graph_events` → 图引擎层监听器。
+
+### 6. 扩展建议：加新节点的 Checklist
+
+新增节点时至少要完成以下动作：
+
+1. 定义 `NodeType`、`NodeData` 模型，描述配置项与变量选择器。
+2. 在 `_run()` 中返回 `NodeRunResult` 或 `yield` 合适的 `NodeEventBase`，记得处理同步/流式两种场景。
+3. 将节点类登记到 `NODE_TYPE_CLASSES_MAPPING`，必要时实现 `_extract_variable_selector_to_variable_mapping()`。
+4. 为关键路径编写单元测试，覆盖变量解析、错误策略与事件序列。
 
 ## 动手任务
-- 选一个节点，列出其 `_run()` 的输入输出，并画出变量依赖图。  
-- 尝试在笔记中模拟编写一个伪节点类，确保覆盖基类要求的接口。
+
+- 选一个节点，列出其 `_run()` 的输入、输出和事件序列，并画出变量依赖图。
+- 尝试写一个伪节点类草稿，包含 `NodeType` 声明、`NodeRunResult` 返回以及最小的事件处理逻辑。
 
 ## 思考题
-- 节点事件与图事件是否存在重复信息？能否统一？  
-- 如果要新增“长时间运行”的节点，需要留意哪些超时或心跳逻辑？
+
+- 节点事件与图事件是否存在冗余字段？有哪些字段是为不同层的消费者准备的？
+- 如果要新增“长时间运行”的节点，需要在哪些事件里注入心跳或进度信息？
 
 ## 延伸阅读
-- `api/services/tools/` 或 `api/services/agent_service.py` 中使用节点的场景
+
+- `api/services/tools/`、`api/services/agent_service.py` 中的节点使用场景
 - `api/tests/unit_tests/core/workflow/nodes/` 的测试策略
-- `api/core/workflow/node_events/listeners/`（如有）
+- `api/core/workflow/node_events/listeners/`（若存在）
 

--- a/docs/tutorials/backend/06_services_and_extensions.md
+++ b/docs/tutorials/backend/06_services_and_extensions.md
@@ -1,49 +1,91 @@
 # 06 业务协作与扩展机制
 
+穿过节点车间后，导览员领我们来到“指挥塔”。这里是服务层与仓储层的集散地：左手边的 `WorkflowService` 正与核心域握手，右手边的扩展墙面则挂着
+日志、监控、存储的开关。搞清楚这些角色，才能知道一条运行记录如何被落盘、一个插件凭据如何进入节点，亦或多租户信息怎样在整条链路保持隔离。
+
 ## 学习成果
-- 说明服务层、仓储层如何与核心工作流域协同管理运行记录与配置
-- 理解插件、工具、扩展点的装配方式，掌握新增能力的入口
-- 总结工作流在多租户、权限、配置场景下的关键实现
+
+- 说明服务层与仓储层的依赖注入方式，以及它们与核心工作流域的协同关系。
+- 理解插件、工具、扩展点的装配流程，掌握新增能力的入口与注意事项。
+- 总结多租户、系统变量、监控扩展在工作流运行过程中的关键实现。
 
 ## 引导问题
-1. `DifyAPIRepositoryFactory` 如何返回具体仓储？与核心仓储之间的关系是什么？
-2. 插件/工具调用在哪个层处理？如何与节点或服务集成？
-3. 多租户或 Workspace 信息怎样在服务层传递到核心域？
+
+1. `DifyAPIRepositoryFactory` 如何基于配置返回具体仓储？它与核心仓储工厂的职责边界在哪里？
+2. `WorkflowService`、`WorkflowAppService` 分别负责哪些业务能力？它们如何与 Graph Engine 产生的数据对接？
+3. 插件或工具的凭据在服务层如何管理，并在节点执行时被使用？
+4. 多租户与系统变量信息如何一路传递到核心域并回写输出？
+5. 扩展（Extensions）如何在 Flask 应用初始化时挂接额外的日志、健康检查或请求追踪？
 
 ## 必读源码
+
 - `api/repositories/factory.py:1`
-- `api/core/repositories/__init__.py` 与工作流相关仓储实现
-- `api/services/workflow_app_service.py:1`、`api/services/workspace_service.py:1`
-- `api/services/plugin`、`api/services/tools`、`api/services/agent_service.py:1`
+- `api/core/repositories/factory.py:1` 及对应仓储实现
+- `api/services/workflow_service.py:47`
+- `api/services/workflow_app_service.py:12`
+- `api/services/plugin/`、`api/services/tools/`、`api/services/agent_service.py`
 - `api/core/workflow/system_variable.py:1`
-- `extensions/ext_*` 中与工作流相关的扩展（如存储、身份等）
+- `api/extensions/ext_app_metrics.py:1`、`api/extensions/ext_request_logging.py:1`
 
 ## Walkthrough
-1. **仓储工厂与会话管理**  
-   - 追踪 `sessionmaker` 如何被注入仓储，理解事务边界与 commit 策略。  
-   - 列出与工作流节点执行记录、运行日志相关的仓储实现。
-2. **服务层与核心域交互**  
-   - 观察 `WorkflowService` 如何在核心域返回结果后更新数据库、发送事件。  
-   - 查找涉及变量同步、配置读取的服务函数。
-3. **插件与工具扩展**  
-   - 阅读 `services/plugin` 目录，了解凭证管理、插件注册流程。  
-   - 分析工具（如 HTTP、Agent 扩展）如何在服务层初始化并在节点中调用。
-4. **多租户与权限**  
-   - 研究 `system_variable.py`、`context` 管理，确认 tenant、user 等信息的传播路径。  
-   - 查阅相关验证逻辑确保请求在正确租户下执行。
-5. **横切关注点**  
-   - 探索日志、监控、审计相关的扩展，明确它们如何与工作流运行绑定。
+
+### 1. 仓储工厂：服务层与核心层的双向桥
+
+服务层使用 `DifyAPIRepositoryFactory`（`api/repositories/factory.py`）创建专门面向 API 的仓储实现。构造函数接受 `sessionmaker`，以依赖注入
+方式提供数据库会话，便于测试与多数据库适配。当配置项 `API_WORKFLOW_NODE_EXECUTION_REPOSITORY`、`API_WORKFLOW_RUN_REPOSITORY`
+指向不同类时，工厂会通过 `import_string` 动态加载，实现 Django 风格的可替换后端。【F:api/repositories/factory.py†L1-L80】
+
+核心域在另一侧通过 `DifyCoreRepositoryFactory`（`api/core/repositories/factory.py`）提供运行态写入仓储。它除了接收 `sessionmaker`，还
+需要当前用户、应用 ID、触发来源等上下文，以便对运行记录进行租户与触发方隔离。这两个工厂分别服务于“服务层查询/展示场景”和“核心引擎持久化场
+景”，既解耦了实现，又可以通过配置实现混合后端（例如在线使用 PostgreSQL，异步写入走 Celery）。【F:api/core/repositories/factory.py†L1-L120】
+
+### 2. WorkflowService：运行管理的门房
+
+`WorkflowService`（`api/services/workflow_service.py:47`）在构造时注入节点执行仓储，提供草稿加载、发布版本校验、节点调试等接口。当调用单步调试
+时，它会读取草稿版本的图结构，构造 `WorkflowEntry.single_step_run()` 并把返回的事件流转换成前端可消费的格式；查询节点最近一次执行则直接调仓储
+的 `get_node_last_execution()`，确保读路径不依赖核心域的运行逻辑。【F:api/services/workflow_service.py†L47-L160】
+
+工作流运行日志展示则由 `WorkflowAppService`（`api/services/workflow_app_service.py:12`）负责。它以 SQLAlchemy 2.0 风格拼接查询，支持多条件过
+滤、分页，并通过 `WorkflowRun`、`WorkflowAppLog` 关联 end-user / account 信息，满足控制台的搜索需求。【F:api/services/workflow_app_service.py†L12-L120】
+
+### 3. 插件、工具与 Agent：服务层如何喂给节点
+
+插件与工具的凭据管理散落在 `api/services/plugin/` 与 `api/services/tools/`。例如工具服务会负责校验凭据、保存用户自定义配置，再在节点执行
+时通过 `ToolNode` 的 `BaseNodeData` 注入。Agent 服务则协调工具集合与策略，最终由 `AgentNode` 在 `_run()` 中调用。理解这一层的职责后，新增
+一个外部能力通常需要：
+
+1. 在服务层添加凭据管理与业务规则。
+2. 在节点数据模型中暴露可配置项。
+3. 在节点运行逻辑中读取服务层写入的配置，调用 Runtime 或 SDK。
+
+### 4. 多租户上下文与系统变量
+
+系统变量模型位于 `api/core/workflow/system_variable.py`，包含 `user_id`、`app_id`、`workflow_id`、`workflow_execution_id` 等字段。服务层在构造
+`WorkflowAppRunner` 时，将这些信息装入 `SystemVariable`，最终被 `VariablePool` 注入节点运行环境。模型通过 `AliasChoices` 同时兼容历史字段
+（如 `workflow_run_id`），确保老版本数据不会出错。【F:api/core/workflow/system_variable.py†L1-L120】
+
+多租户隔离还体现在仓储查询条件上：无论是 `WorkflowService` 的草稿查询，还是 `WorkflowAppService` 的运行记录，都显式带上 `tenant_id` 与
+`app_id` 过滤，避免串租户数据。【F:api/services/workflow_service.py†L47-L160】【F:api/services/workflow_app_service.py†L12-L120】
+
+### 5. Extensions：把横切能力插到应用工厂
+
+扩展位于 `api/extensions/`，由 `app_factory` 在初始化阶段逐一挂载。以 `ext_app_metrics` 为例，它在 `after_request` 钩子中写入版本号 Header，并提
+供 `/health`、`/threads`、`/db-pool-stat` 诊断接口；`ext_request_logging` 根据配置订阅 Flask `request_started` / `request_finished` 信号，记录进出
+口的 JSON 载荷，方便调试 API 请求。这些扩展统一由 `create_app()` 注册，必要时可以根据配置开关启停。【F:api/extensions/ext_app_metrics.py†L1-L80】【F:api/extensions/ext_request_logging.py†L1-L120】
 
 ## 动手任务
-- 列出工作流运行涉及的主要仓储类，标注其负责的数据表和关键方法。  
-- 选择一个插件或工具，整理其从配置、注入到使用的完整流程。
+
+- 列出工作流运行涉及的主要仓储类（API 层与核心层各自至少两个），标注负责的数据表和关键方法。
+- 选择一个插件或工具服务，梳理其从保存凭据 → 注入节点 → 节点调用 Runtime 的完整流程。
 
 ## 思考题
-- 如果要接入新的外部知识库，哪些服务与核心模块需要扩展？  
-- 在多租户场景下，哪些信息必须在工作流运行时隔离？怎样验证？
+
+- 如果要接入新的外部知识库，哪些服务需要扩展？是否需要新增节点类型或仓储？
+- 在多租户场景下，除了系统变量，哪些缓存/队列键名也必须带上租户信息以避免串数据？
 
 ## 延伸阅读
+
 - `api/core/workflow/variable_loader.py`
-- `api/services/dataset_service.py` 中与 workflow graph 关联的代码
-- `api/extensions/ext_app_metrics.py`、`ext_request_logging.py`
+- `api/services/dataset_service.py` 中与 workflow graph 关联的逻辑
+- `api/core/workflow/graph_engine/layers/persistence.py`
 

--- a/docs/tutorials/backend/07_testing_and_debugging.md
+++ b/docs/tutorials/backend/07_testing_and_debugging.md
@@ -1,49 +1,89 @@
 # 07 测试策略与调试路径
 
+巡礼的最后一站是“实验室”。这里摆放着覆盖层层模块的单元测试、用于本地排障的脚本、以及能让事件流一览无遗的调试层。掌握这些工具，你就能
+在不依赖生产环境的前提下复现大多数问题，并给出可靠修复方案。
+
 ## 学习成果
-- 熟悉核心工作流模块的单元测试、夹具组织方式
-- 能够使用测试案例快速定位业务逻辑、复现问题
-- 掌握常见调试技巧：日志层、事件监听、断点设置
+
+- 熟悉核心工作流模块的单元测试目录、夹具组织方式与模拟策略。
+- 能够快速定位某段逻辑对应的测试案例，并据此复现或验证缺陷。
+- 掌握常用调试技巧：调试层日志、事件监听、Redis/命令通道的模拟。
 
 ## 引导问题
-1. 工作流相关测试主要分布在哪些目录？夹具如何复用？
-2. 单元测试如何模拟变量池、图引擎运行？有哪些 Mock？
-3. 日志、事件能提供哪些调试线索？如何开启更详细的输出来定位问题？
+
+1. 工作流相关测试主要分布在哪些子目录？各自关注什么？
+2. 单元测试如何模拟 Graph Engine、变量池和外部依赖（如 Redis）？
+3. 运行测试时有哪些推荐脚本或超时时间设置？
+4. 调试日志层、事件监听器如何帮助还原节点执行？
+5. 出现运行异常时，应该在哪些断点或事件上排查？
 
 ## 必读源码
-- `api/tests/unit_tests/core/workflow/` 全部子目录
-- `api/tests/unit_tests/core/workflow/graph_engine/`、`nodes/`、`entities/`
-- `api/tests/conftest.py` 与工作流相关夹具
+
+- `api/tests/unit_tests/core/workflow/`
+- `api/tests/unit_tests/conftest.py`
 - `dev/pytest/pytest_unit_tests.sh`
-- `api/core/workflow/graph_engine/layer/debug_logging_layer.py`（或同类）
-- `api/core/workflow/graph_events/listeners/`（如有）
+- `api/core/workflow/graph_engine/layers/debug_logging.py`
+- `api/core/workflow/graph_engine/layers/persistence.py`
 
 ## Walkthrough
-1. **测试目录导览**  
-   - 归纳 `tests/unit_tests/core/workflow/` 子目录（graph、engine、nodes、utils 等），记录每个目录关注点。  
-   - 总结常见 Fixture（如 `workflow_builder`, `variable_pool`）的定义位置与用途。
-2. **构造与断言**  
-   - 选择一个 graph_engine 测试，分析 Arrange-Act-Assert 三步如何组织，提炼可复用技巧。  
-   - 注意对事件、状态、变量池的断言方式，为调试提供参考。
-3. **命令与脚本**  
-   - 学习 `dev/pytest/pytest_unit_tests.sh` 的执行逻辑，了解调试工作流模块时的推荐命令。  
-   - 结合 `make lint`、`make type-check` 形成常规检查流程。
-4. **日志与层辅助**  
-   - 阅读 Debug Logging Layer 或其他辅助层，记录如何在本地启用详细日志。  
-   - 探索事件监听器如何输出或收集诊断信息。
-5. **实战调试建议**  
-   - 总结断点位置（如节点 `_run`、变量池写入、事件广播）与常见异常排查步骤。
+
+### 1. 测试目录导览
+
+`api/tests/unit_tests/core/workflow/` 目录按职能划分：`graph_engine/` 关注调度器状态、命令通道；`graph/` 负责 DSL 转换与校验；`nodes/` 则针对
+单个节点 `_run()` 的输入输出；`entities/`、`utils/` 等目录测试数据结构或辅助函数。了解目录结构，能让你根据 bug 类型迅速定位已有案例。
+
+全局 `conftest.py`（`api/tests/unit_tests/conftest.py`）提供 Flask 应用上下文与 Redis Mock。它在模块级别打补丁 `ext_redis.redis_client`，确保
+所有测试共享同一组伪造的 `get/set` 行为，并在每个用例前自动重置，避免状态泄漏。这种方式让 Graph Engine 的命令通道、缓存逻辑都能在纯内存
+环境运行。【F:api/tests/unit_tests/conftest.py†L1-L60】
+
+### 2. Arrange-Act-Assert：以 Graph Engine 测试为例
+
+挑一个图引擎测试（如 `test_workflow_entry.py`），你会看到典型的三段式结构：
+
+1. **Arrange**：构造变量池、Graph 模板、节点假实现。
+2. **Act**：调用 `WorkflowEntry.run()` 或 Graph Engine 的 `run()` 方法，让生成器产出事件。
+3. **Assert**：断言事件序列、节点状态、变量池输出，与预期完全匹配。
+
+通过阅读这些断言，可以总结哪些字段是运行正确与否的信号（例如 `WorkflowNodeExecutionStatus`、`GraphRunSucceededEvent.outputs`），在调试
+时对照即可。
+
+### 3. 运行脚本与超时
+
+`dev/pytest/pytest_unit_tests.sh` 定义了默认的运行命令：设置 `PYTEST_TIMEOUT`（默认 20 秒），然后执行 `pytest --timeout <值> api/tests/unit_tests`。
+当你只需跑单个目录时，可以覆写 `PYTEST_TIMEOUT` 并传入 `-k` 过滤表达式。结合仓库根目录的 `make lint`、`make type-check`，就形成了基本的本地
+质量验证流程。【F:dev/pytest/pytest_unit_tests.sh†L1-L20】
+
+### 4. 调试层与日志
+
+Graph Engine 支持挂载 `DebugLoggingLayer`（`api/core/workflow/graph_engine/layers/debug_logging.py`）：
+
+- `on_graph_start()` 会打印分隔线并记录初始状态；
+- `on_event()` 针对不同事件输出详细日志（包含重试次数、输出摘要等），还能按需显示 inputs、outputs、process_data；
+- 内部还维护了节点统计计数器，方便确认哪些节点成功、失败或重试。
+
+在本地调试时，只需在 `WorkflowEntry` 构造后手动 `graph_engine.layer(DebugLoggingLayer(level="DEBUG", include_inputs=True))`，就能获得详
+细事件轨迹。【F:api/core/workflow/graph_engine/layers/debug_logging.py†L1-L200】
+
+### 5. 实战排障建议
+
+- **节点级问题**：在节点 `_run()` 中打断点，关注 `NodeRunResult` 或 `StreamChunkEvent` 是否符合预期。
+- **变量不对**：检查 `VariablePool` 的 `add/get` 调用，或在测试里断言 `graph_runtime_state.outputs`。
+- **运行停止/异常**：观察事件流是否出现 `NodeRunFailedEvent`、`GraphRunFailedEvent`；结合 `DebugLoggingLayer` 日志定位。
+- **命令通道**：查看 Redis Mock 的调用次数，确保暂停/恢复命令正确发送。
 
 ## 动手任务
-- 运行选定的单元测试（在本地或思想实验），对照源码标注关键断言。  
-- 尝试启用 DebugLoggingLayer，设计一份日志输出示例（无需真实运行）。
+
+- 运行任意一个 `graph_engine` 相关测试，对照源码记录关键断言对应的实现位置。
+- 在本地启动一个最小化工作流（或使用测试夹具），启用 `DebugLoggingLayer`，整理一段包含开始/成功/流式片段的日志样例。
 
 ## 思考题
-- 目前测试覆盖面是否足够？哪些模块缺乏自动化验证？  
-- 如何构造端到端测试或集成测试来覆盖跨服务协作的场景？
+
+- 当前单元测试覆盖是否包含所有节点类型？对于新节点应补充哪些场景？
+- 如果要编写端到端测试覆盖服务层到节点执行的链路，你会如何模拟外部依赖（模型、Redis、数据库）？
 
 ## 延伸阅读
-- `CONTRIBUTING.md` 中的测试指南  
-- `docs/zh-CN/README.md` 对工作流功能的描述  
-- 相关 GitHub Issues/PR，了解真实问题的调试过程
+
+- `CONTRIBUTING.md` 中的测试指南
+- `docs/zh-CN/README.md` 对工作流功能的描述
+- 真实 Issues/PR 中的调试讨论，了解常见排障思路
 


### PR DESCRIPTION
## Summary
- expand the backend basics tutorials to fully document node internals and event propagation
- detail service/repository coordination and extension hooks for workflow operations
- add guidance on testing workflows and using debugging layers for local troubleshooting

## Testing
- not run (docs changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68fc4e92e30c8326a8e10f218ef21b15)